### PR TITLE
Add '--remove-all-unused-imports' to autoflake options

### DIFF
--- a/autoload/neoformat/formatters/python.vim
+++ b/autoload/neoformat/formatters/python.vim
@@ -38,7 +38,7 @@ endfunction
 function! neoformat#formatters#python#autoflake() abort
     return {
                 \ 'exe': 'autoflake',
-                \ 'args': ['--in-place', '--remove-duplicate-keys', '--expand-star-imports'],
+                \ 'args': ['--remove-all-unused-imports', '--in-place', '--remove-duplicate-keys', '--expand-star-imports'],
                 \ 'stdin': 0,
                 \ }
 endfunction
@@ -64,5 +64,6 @@ function! neoformat#formatters#python#pydevf() abort
     return {
                 \ 'exe': 'pydevf',
                 \ 'replace': 1,
+                \ 'args': ['-', '2>/dev/null'],
                 \ }
 endfunction


### PR DESCRIPTION
It's my mistake for not checking availability on the non-standard library. I have added the option, it should work as expected, but due to the limitation from autoflake, it won't work on the multi-line import.
https://github.com/myint/autoflake/issues/41